### PR TITLE
fix(create-handler): 🐞 remove response from resolver func options, router accept json, urlencoded

### DIFF
--- a/examples/express-ts/index.ts
+++ b/examples/express-ts/index.ts
@@ -99,15 +99,34 @@ guardTest.handler({
 const requestValidation = router.path('/request-validation/:id')
 
 requestValidation.handler({
-	method: 'get',
-	params: z.object({
-		id: z.string().transform((v) => parseInt(v)),
-	}),
+	method: 'post',
+	request: {
+		params: z.object({
+			id: z.string().transform((v) => parseInt(v)),
+		}),
+		query: z.object({
+			limit: z
+				.string()
+				.default('10')
+				.transform((v) => Number(v)),
+		}),
+		body: z.object({
+			age: z.number(),
+			dateOfBirth: z
+				.string()
+				.regex(/^\d\d\d\d-\d\d-\d\d$/g, {
+					message: 'dateOfBirth must be a date formate string (YYYY-MM-DD).',
+				})
+				.transform((v) => new Date(v)),
+		}),
+	},
 	response: {
 		200: z.string(),
 	},
 	resolver({ ctx }) {
 		const { id } = ctx.params
+
+		console.log(ctx.body)
 
 		return {
 			200: 'request validation id: ' + id + ' and type is: ' + typeof id,

--- a/lib/create-router.ts
+++ b/lib/create-router.ts
@@ -1,90 +1,98 @@
 import type { Express, Router, RequestHandler } from 'express'
 import type { Path, PathOptions, PathReturnType } from './create-path'
 
+import express from 'express'
 import { createPath } from './create-path'
 
 export type UseFunction = (...handlers: RequestHandler[]) => Router
 
 export interface SetupOptions {
-  paths: PathReturnType[]
+	paths: PathReturnType[]
 }
 
 export interface CreateRouterReturnType {
-  /** Express's `use` function. */
-  use: UseFunction
-  /**
-   * Generate a path object to bind with router setup function.
-   *
-   * @param path
-   * @param pathOptions
-   *
-   * example:
-   * ```ts
-   * const app = express()
-   * const router = createRouter(Router())
-   *
-   * const users = router.path('/users')
-   *
-   * users.handler({
-   *  method: 'get',
-   *  resolver() {
-   *   return 'users'
-   *  }
-   * })
-   *
-   * router.setup(app, {
-   *  paths: [users.meta]
-   * })
-   * ```
-   */
-  path: (path: Path, options?: PathOptions) => PathReturnType
-  /**
-   * Setup router with express app instance and bind paths to the router.
-   *
-   * @param expressApp
-   * @param setupOptions
-   *
-   * example:
-   * ```ts
-   * import express, { Router } from 'express'
-   * const app = express()
-   * const router = createRouter(Router())
-   * const users = router.path('/users')
-   * ...
-   * router.setup(app, {
-   *   paths: [users]
-   * })
-   * ```
-   */
-  setup: (expressApp: Express, options: SetupOptions) => void
+	/** Express's `use` function. */
+	use: UseFunction
+	/**
+	 * Generate a path object to bind with router setup function.
+	 *
+	 * @param path
+	 * @param pathOptions
+	 *
+	 * example:
+	 * ```ts
+	 * const app = express()
+	 * const router = createRouter(Router())
+	 *
+	 * const users = router.path('/users')
+	 *
+	 * users.handler({
+	 *  method: 'get',
+	 *  resolver() {
+	 *   return 'users'
+	 *  }
+	 * })
+	 *
+	 * router.setup(app, {
+	 *  paths: [users.meta]
+	 * })
+	 * ```
+	 */
+	path: (path: Path, options?: PathOptions) => PathReturnType
+	/**
+	 * Setup router with express app instance and bind paths to the router.
+	 *
+	 * @param expressApp
+	 * @param setupOptions
+	 *
+	 * example:
+	 * ```ts
+	 * import express, { Router } from 'express'
+	 * const app = express()
+	 * const router = createRouter(Router())
+	 * const users = router.path('/users')
+	 * ...
+	 * router.setup(app, {
+	 *   paths: [users]
+	 * })
+	 * ```
+	 */
+	setup: (expressApp: Express, options: SetupOptions) => void
 }
 
 export function createRouter(router: Router): CreateRouterReturnType {
-  const use: UseFunction = (...handlers) => router.use(...handlers)
+	const use: UseFunction = (...handlers) => router.use(...handlers)
 
-  const path = (path: Path, options?: PathOptions) =>
-    createPath(router, path, options)
+	const path = (path: Path, options?: PathOptions) =>
+		createPath(router, path, options)
 
-  const setup = (expressApp: Express, options: SetupOptions) => {
-    const { paths } = options
+	const setup = (expressApp: Express, options: SetupOptions) => {
+		expressApp.use(
+			// accept `application/json`
+			express.json(),
+			// accept `application/x-www-form-urlencoded`
+			express.urlencoded({ extended: false }),
+		)
 
-    paths.forEach((eachPath) => {
-      const { _path, _handlerColl } = eachPath
+		const { paths } = options
 
-      _handlerColl.forEach((eachHandler) => {
-        const { method, handler } = eachHandler
+		paths.forEach((eachPath) => {
+			const { _path, _handlerColl } = eachPath
 
-        if (method === 'get') return router.get(_path, handler)
-        else if (method === 'post') return router.post(_path, handler)
-        else if (method === 'put') return router.put(_path, handler)
-        else if (method === 'patch') return router.patch(_path, handler)
-        else if (method === 'delete') return router.delete(_path, handler)
-        else throw new Error(`Unknown method: ${method}`)
-      })
-    })
+			_handlerColl.forEach((eachHandler) => {
+				const { method, handler } = eachHandler
 
-    expressApp.use(router)
-  }
+				if (method === 'get') return router.get(_path, handler)
+				else if (method === 'post') return router.post(_path, handler)
+				else if (method === 'put') return router.put(_path, handler)
+				else if (method === 'patch') return router.patch(_path, handler)
+				else if (method === 'delete') return router.delete(_path, handler)
+				else throw new Error(`Unknown method: ${method}`)
+			})
+		})
 
-  return { use, path, setup }
+		expressApp.use(router)
+	}
+
+	return { use, path, setup }
 }


### PR DESCRIPTION
- move params, query and body inside request object
- move params, query and body inside request
object
 - route now enable `express.json()` and `express.urlencoded({ extended: false })`

BREAKING CHANGE: - params, query and body can only be defined inside request option